### PR TITLE
Use camel case for PBF property names

### DIFF
--- a/lib/prognose-vehicle-position.js
+++ b/lib/prognose-vehicle-position.js
@@ -131,7 +131,7 @@ const prognoseAndPublishVehiclePosition = async (db, vehicleId, tVehiclePos) => 
 				: VehicleStopStatus.IN_TRANSIT_TO
 		) : null,
 		// todo: congestion_level?
-		occupancy_status: paxToOccupancyStatus(latestVehiclePax),
+		occupancyStatus: paxToOccupancyStatus(latestVehiclePax),
 	}
 
 	const additionalData = {


### PR DESCRIPTION
According to https://github.com/MobilityData/gtfs-realtime-bindings/blob/9354c5073badbd4fbfc54bbed17f5c4428afebcd/nodejs/gtfs-realtime.js#L1827 it's `occupancyStatus` not `occupancy_status`.